### PR TITLE
feat: support darwin/arm64

### DIFF
--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -15,6 +15,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         version:
+          - "1.11.0"
           - "1.14.0"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -12,29 +12,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04 # ubuntu-earliest
           - ubuntu-latest
-          - macos-10.15 # macos-earliest
           - macos-latest
-        version: # all major versions
-          # Lowest version that supports the version argument,
-          # also tests the older download method
-          - "1.0.0"
-          - "latest:1"
-          - "latest"
-        exclude:
-          # v1.2.0 adds support for macos
-          - os: macos-10.15
-            version: "1.0.0"
-          - os: macos-latest
-            version: "1.0.0"
+        version:
+          - "1.14.0"
     runs-on: ${{ matrix.os }}
     steps:
-      # Configures the node version used on GitHub-hosted runners
-      - uses: actions/setup-node@v1
-        with:
-          # The Node.js version to configure
-          node-version: ${{ matrix.node }}
       - name: Test plugin
         uses: asdf-vm/actions/plugin-test@v1
         with:

--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   plugin-test:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # asdf-container-structure-test
 
 ASDF Plugin for container-structure-test
+
+⚠️ Only versions with binaries hosted on GitHub (>= v1.11.0) are supported.

--- a/bin/download
+++ b/bin/download
@@ -17,7 +17,7 @@ else
 fi
 
 arch=$(uname -m)
-if [[ "$platform_arch" == "x86_64" ]]; then
+if [[ "$arch" == "x86_64" ]]; then
   arch="amd64"
 fi
 

--- a/bin/download
+++ b/bin/download
@@ -19,7 +19,7 @@ fi
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then
   arch="amd64"
-else if [[ "$arch" == "arm64" && "$platform" == "darwin" ]]; then
+elif [[ "$arch" == "arm64" && "$platform" == "darwin" ]]; then
   # there is no darwin arm64 build... yet?
   arch="amd64"
 fi

--- a/bin/download
+++ b/bin/download
@@ -16,11 +16,9 @@ else
   exit 1
 fi
 
-if [[ $(uname -m) == "x86_64" ]]; then
+arch=$(uname -m)
+if [[ "$platform_arch" == "x86_64" ]]; then
   arch="amd64"
-else
-  echo >&2 "Unsupported architecture: $(uname -m)."
-  exit 1
 fi
 
 mkdir -p "${ASDF_DOWNLOAD_PATH}"
@@ -28,15 +26,9 @@ mkdir -p "${ASDF_DOWNLOAD_PATH}"
 echo "Downloading container-structure-test v${ASDF_INSTALL_VERSION}"
 
 if [[ "${ASDF_INSTALL_VERSION}" == "0."* ]] || [[ "${ASDF_INSTALL_VERSION}" == "1.0."* ]] || [[ "${ASDF_INSTALL_VERSION}" == "1.1."* ]]; then
-  if [[ "${platform}" == "linux" ]] && [[ "${arch}" == "amd64" ]]; then
-    # Try downloading with the platform and architecture (>= v1.2.0)
-    curl --silent --fail --show-error --location \
-      "https://storage.googleapis.com/container-structure-test/v${ASDF_INSTALL_VERSION}/container-structure-test" \
-      -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"
-  else
-    echo >&2 "v${ASDF_INSTALL_VERSION} only supports linux and amd64."
-    exit 1
-  fi
+  curl --silent --fail --show-error --location \
+    "https://storage.googleapis.com/container-structure-test/v${ASDF_INSTALL_VERSION}/container-structure-test" \
+    -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"
 else
   curl --silent --fail --show-error --location \
     "https://storage.googleapis.com/container-structure-test/v${ASDF_INSTALL_VERSION}/container-structure-test-${platform}-${arch}" \

--- a/bin/download
+++ b/bin/download
@@ -29,5 +29,5 @@ mkdir -p "${ASDF_DOWNLOAD_PATH}"
 echo "Downloading container-structure-test v${ASDF_INSTALL_VERSION}"
 
 curl --silent --fail --show-error --location \
-  "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${ASDF_INSTALL_CERSION}/container-structure-test-${platform}-${arch}" \
+  "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${ASDF_INSTALL_VERSION}/container-structure-test-${platform}-${arch}" \
   -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"

--- a/bin/download
+++ b/bin/download
@@ -19,18 +19,15 @@ fi
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then
   arch="amd64"
+else if [[ "$arch" == "arm64" && "$platform" == "darwin" ]]; then
+  # there is no darwin arm64 build... yet?
+  arch="amd64"
 fi
 
 mkdir -p "${ASDF_DOWNLOAD_PATH}"
 
 echo "Downloading container-structure-test v${ASDF_INSTALL_VERSION}"
 
-if [[ "${ASDF_INSTALL_VERSION}" == "0."* ]] || [[ "${ASDF_INSTALL_VERSION}" == "1.0."* ]] || [[ "${ASDF_INSTALL_VERSION}" == "1.1."* ]]; then
-  curl --silent --fail --show-error --location \
-    "https://storage.googleapis.com/container-structure-test/v${ASDF_INSTALL_VERSION}/container-structure-test" \
-    -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"
-else
-  curl --silent --fail --show-error --location \
-    "https://storage.googleapis.com/container-structure-test/v${ASDF_INSTALL_VERSION}/container-structure-test-${platform}-${arch}" \
-    -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"
-fi
+curl --silent --fail --show-error --location \
+  "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${ASDF_INSTALL_CERSION}/container-structure-test-${platform}-${arch}" \
+  -o "${ASDF_DOWNLOAD_PATH}/container-structure-test"


### PR DESCRIPTION
- adds support of for darwin/arm64. there's no arm64 build, but we can just install the amd64 build in that case. 
- removes the platform and arch guards the download script was doing. seems like we should make an effort to download whatever rather than requiring these scripts maintain parity with the container-structure-tests repo.
- changes the download location from storage.googleapis.com to github. _this means that only versions with prebuilt binaries on GitHub are supported_ (>= v1.11.0). considering the slow pace of releases, this impacts release > a year old. if you need old versions, consider using the upstream plugin.